### PR TITLE
Newline termination in string responses

### DIFF
--- a/scpi.py
+++ b/scpi.py
@@ -4,7 +4,7 @@ import select
 class SCPI(object):
     
     _socket = None
-    _chunk = 128 # buf size
+    _chunk = 4 * 1024 # buf size
     _vocal = False
     _timeout = 0.150 # Float timeout in secs
     
@@ -53,8 +53,11 @@ class SCPI(object):
 
             if r: # socket readable
                 data = self._socket.recv(self._chunk)
+                length=len(data)
                 if data: 
                     buf += data
+                    if data[length-1] == "\n":
+                        data = False
                 else: # Socket readable but there is no data, disconnected.
                     data = False
                     self.close()
@@ -85,4 +88,3 @@ class SCPI(object):
     def __del__(self):    
         if self._socket is not None: self._socket.close()
         self._socket = None
-


### PR DESCRIPTION
Hi,

Thanks for providing this code! While using it I recognized that by increasing the timeout it also takes longer until queries are completed. It almost appears that after completely receiving a response the code then waits for the full timeout span before the method then successfully exists. 

If I understand the SCPI definition correctly then responses are terminated with a new line ('\n') character. I've also found this check in [another SCPI client written in Python](https://community.keysight.com/thread/24432). This current implementation doesn't do that. With this pull request I would like to add the check for new line which seems to eliminate the issue.

In addition for larger query sizes it would be beneficial to use a larger buffer size. I think 4k of memory can easily spared on most systems so I would make this the default buffer size.

Let me know what you think about the changes.